### PR TITLE
style: 解决当task名称过长时, 右侧Editor会撑开的样式问题

### DIFF
--- a/src/components/task/TaskEditor.vue
+++ b/src/components/task/TaskEditor.vue
@@ -13,7 +13,7 @@ function handleInput(e: Event) {
 <template>
   <div>
     <div v-if="taskStore.currentActiveTask">
-      <h1 contenteditable="true" class="text-3xl break-all" @input="handleInput">
+      <h1 contenteditable="true" class="text-3xl" @input="handleInput">
         {{ taskStore.currentActiveTask.title }}
       </h1>
       <div class="mt-2">

--- a/src/components/task/TaskEditor.vue
+++ b/src/components/task/TaskEditor.vue
@@ -13,7 +13,7 @@ function handleInput(e: Event) {
 <template>
   <div>
     <div v-if="taskStore.currentActiveTask">
-      <h1 contenteditable="true" class="text-3xl" @input="handleInput">
+      <h1 contenteditable="true" class="text-3xl break-all" @input="handleInput">
         {{ taskStore.currentActiveTask.title }}
       </h1>
       <div class="mt-2">

--- a/src/pages/Task.vue
+++ b/src/pages/Task.vue
@@ -27,8 +27,8 @@ import TheHeader from '@/components/header/TheHeader.vue'
     <NLayoutContent>
       <NLayoutContent content-style="padding: 24px">
         <div class="flex w-full h-full">
-          <TaskList class="flex-1" />
-          <TaskEditor class="flex-1" />
+          <TaskList class="flex-1 w-0" />
+          <TaskEditor class="flex-1 w-0" />
         </div>
       </NLayoutContent>
     </NLayoutContent>


### PR DESCRIPTION
[](https://github.com/cuixiaorui/vue3-dida/issues/12)