### PR TITLE
fix: remove taskList list-leave style

### DIFF
--- a/src/components/task/TaskList.vue
+++ b/src/components/task/TaskList.vue
@@ -98,13 +98,11 @@ useEventListener(
 </template>
 
 <style scoped>
-.list-enter-active,
-.list-leave-active {
+.list-enter-active {
   transition: all 0.5s ease;
 }
 
-.list-enter-from,
-.list-leave-to {
+.list-enter-from {
   opacity: 0;
   transform: translateX(30px);
 }


### PR DESCRIPTION
Removed the leave style in the list component. This effect seems a bit redundant in my opinion.

before:
![before](https://raw.githubusercontent.com/enochzzz/picture/main/dida/before.gif)

after:
![after](https://raw.githubusercontent.com/enochzzz/picture/main/dida/after.gif)