### PR TITLE
refactor: split components

### DIFF
--- a/src/components/task/TaskItem.vue
+++ b/src/components/task/TaskItem.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { NPopover } from 'naive-ui'
-import type { Task } from '@/store'
 import { TaskState, useTaskStore } from '@/store'
 import { useTaskRightContextMenu } from '@/composable/taskRightContextMenu'
+import type { Task } from '@/store'
 
 interface Props {
   task: Task

--- a/src/components/task/TaskLeftListView.vue
+++ b/src/components/task/TaskLeftListView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import TaskLeftListNTree from '@/views/task/TaskLeftListNTree.vue';
+import TaskLeftListNTree from '@/views/task/TaskLeftListNTree.vue'
 import TaskLeftListProject from '@/views/task/TaskLeftListProject.vue'
 </script>
 

--- a/src/components/task/TaskLeftListView.vue
+++ b/src/components/task/TaskLeftListView.vue
@@ -1,134 +1,15 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
-import { NTree } from 'naive-ui'
-import { Icon } from '@iconify/vue'
-import { SpecialProjectNames, useTaskStore } from '@/store'
-
-interface TaskListType {
-  key: number
-  icon: string
-  title: `${SpecialProjectNames}`
-}
-const selected = 'bg-[#E7F5EE] dark:bg-[#233633]'
-
-const taskStore = useTaskStore()
-
-const selectedKey = ref([101])
-const listDefaultSelectedKey = ref([100])
-
-const data = ref<any[]>([
-  {
-    key: 100,
-    label: '清单',
-    checkboxDisabled: false,
-    isLeaf: false,
-    children: taskStore.projectNames.map(
-      (projectName, index) => {
-        return {
-          key: 100 + index + 1,
-          label: projectName,
-          isLeaf: true,
-        }
-      },
-    ),
-  },
-])
-
-const taskList = reactive<TaskListType[]>([
-  {
-    key: 1,
-    icon: 'material-symbols:check-box',
-    title: SpecialProjectNames.Complete,
-  },
-  {
-    key: 2,
-    icon: 'mdi:close-box',
-    title: SpecialProjectNames.Failed,
-  },
-  {
-    key: 3,
-    icon: 'material-symbols:delete',
-    title: SpecialProjectNames.Trash,
-  },
-  {
-    key: 4,
-    icon: 'material-symbols:text-snippet-rounded',
-    title: SpecialProjectNames.Abstract,
-  },
-])
-
-const changeSelectedKeyAndActiveProject = (
-  projectName: string,
-  key: number,
-) => {
-  taskStore.changeCurrentActiveProject(projectName)
-  selectedKey.value = [key]
-}
-
-const nodeProps = (treeOption: any) => {
-  return {
-    onClick() {
-      const projectName = treeOption.option.label
-      taskStore.changeCurrentActiveProject(projectName)
-    },
-  }
-}
-
-const changeSelectedKey = (key: number[]) => {
-  selectedKey.value = key
-}
+import TaskLeftListNTree from '@/views/task/TaskLeftListNTree.vue';
+import TaskLeftListProject from '@/views/task/TaskLeftListProject.vue'
 </script>
 
 <template>
   <div>
     <div>
-      <NTree
-        v-model:selected-keys="selectedKey"
-        :default-expanded-keys="listDefaultSelectedKey"
-        block-line
-        :data="data"
-        :node-props="nodeProps"
-        @update:selected-keys="changeSelectedKey"
-      />
+      <TaskLeftListNTree />
     </div>
     <div class="mt-2px">
-      <ul>
-        <li
-          v-for="item in taskList"
-          :key="item.key"
-          li_common
-          pl-4
-          pr-2
-          hover="bg-[#F3F3F5] dark:bg-[#2D2D30]"
-          :class="
-            selectedKey[0] === item.key ? selected : ''
-          "
-          @click="
-            changeSelectedKeyAndActiveProject(
-              item.title,
-              item.key,
-            )
-          "
-        >
-          <div flex>
-            <Icon
-              :icon="item.icon"
-              width="20"
-              class="color-[#9D9FA3]"
-              dark="color-white-b"
-            />
-            <span class="ml-2">{{ item.title }}</span>
-          </div>
-
-          <Icon
-            v-show="selectedKey[0] === item.key"
-            icon="material-symbols:more-horiz"
-            width="20"
-            class="color-[#9D9FA3]"
-            dark="color-white"
-          />
-        </li>
-      </ul>
+      <TaskLeftListProject />
     </div>
   </div>
 </template>

--- a/src/components/task/TaskLeftListView.vue
+++ b/src/components/task/TaskLeftListView.vue
@@ -2,7 +2,6 @@
 import { reactive, ref } from 'vue'
 import { NTree } from 'naive-ui'
 import { Icon } from '@iconify/vue'
-import type { Key } from 'naive-ui/es/cascader/src/interface'
 import { SpecialProjectNames, useTaskStore } from '@/store'
 
 interface TaskListType {
@@ -10,6 +9,7 @@ interface TaskListType {
   icon: string
   title: `${SpecialProjectNames}`
 }
+const selected = 'bg-[#E7F5EE] dark:bg-[#233633]'
 
 const taskStore = useTaskStore()
 
@@ -33,8 +33,6 @@ const data = ref<any[]>([
     ),
   },
 ])
-
-const selected = 'bg-[#E7F5EE] dark:bg-[#233633]'
 
 const taskList = reactive<TaskListType[]>([
   {

--- a/src/components/task/TaskList.vue
+++ b/src/components/task/TaskList.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
-import type { Ref } from 'vue'
 import { computed, ref } from 'vue'
 import { Icon } from '@iconify/vue'
-import { useEventListener } from '@vueuse/core'
-import draggable from 'vuedraggable'
-import TaskItem from './TaskItem.vue'
 import { SpecialProjectNames, useTaskStore } from '@/store'
 import { isDark } from '@/composable/dark'
+import draggable from 'vuedraggable'
+import TaskItem from './TaskItem.vue'
+import { useInput } from '@/hooks'
 
 const taskStore = useTaskStore()
 
 const taskTitle = ref('')
+const dragging = ref(false)
 
 const placeholderText = computed(() => {
   return `添加任务至“${taskStore.currentActiveProject?.name}”，回车即可保存`
@@ -27,62 +27,14 @@ function addTask() {
 const shouldShowTodoAdd = computed(() => {
   const name = taskStore.currentActiveProject?.name
   return (
-    name !== (SpecialProjectNames.Complete as string)
-    && name !== SpecialProjectNames.Trash
-    && name !== SpecialProjectNames.Failed
-    && name !== SpecialProjectNames.Abstract
+    name !== (SpecialProjectNames.Complete as string) &&
+    name !== SpecialProjectNames.Trash &&
+    name !== SpecialProjectNames.Failed &&
+    name !== SpecialProjectNames.Abstract
   )
 })
 
-function useInput() {
-  const inputRef: Ref<HTMLInputElement | null> = ref(null)
-  useEventListener(
-    () => inputRef.value,
-    'blur',
-    () => {
-      const classList = inputRef.value!.classList
-
-      classList.add('bg-gray-100')
-      classList.add('dark:bg-#3B3B3B')
-
-      classList.remove('border-blue')
-      classList.remove('dark:color-black')
-    },
-  )
-
-  useEventListener(
-    () => inputRef.value,
-    'focus',
-    () => {
-      const classList = inputRef.value!.classList
-
-      classList.add('border-blue')
-      classList.add('dark:color-black')
-      classList.remove('bg-gray-100')
-      classList.remove('dark:bg-#3B3B3B')
-    },
-  )
-
-  function onFocus() {
-    inputRef.value!.focus()
-  }
-
-  return {
-    inputRef,
-    onFocus,
-  }
-}
-
 const { inputRef, onFocus } = useInput()
-
-const dragging = ref<boolean>(false)
-const checkMove = (e: any) => {
-  const currentIndex = e.draggedContext.index
-  const futureIndex = e.draggedContext.futureIndex
-  // 貌似vue3的响应机制太牛了，taskstore的task顺序(currentActiveProject和projects中对应的部分)，直接就变了，不需要再手动去改变了
-  // 如果后端要改，这个位置调用接口就行了
-  // taskStore.exchangeTwoTaskByIndex(currentIndex, futureIndex)
-}
 </script>
 
 <template>
@@ -103,7 +55,7 @@ const checkMove = (e: any) => {
         type="text"
         class="w-100% min-w-300px h-38px rounded-6px p-4px pl-12px pr-12px outline-none border-1 b-transparent bg-gray-100 dark:bg-#3B3B3B"
         @keypress.enter="addTask"
-      >
+      />
       <div
         v-show="isPlaceholder"
         class="w-100% min-w-300px absolute top-0 flex items-center h-38px p-4px pl-12px pr-12px border-1 b-transparent select-none color-gray:50"
@@ -128,12 +80,15 @@ const checkMove = (e: any) => {
         name: !dragging ? 'flip-list' : null,
       }"
       class="flex flex-col gap-10px"
-      :move="checkMove"
       @start="dragging = true"
       @end="dragging = false"
     >
       <template #item="{ element, index }">
-        <TaskItem :task="element" :index="index" class="item" />
+        <TaskItem
+          :task="element"
+          :index="index"
+          class="item"
+        />
       </template>
     </draggable>
     <!-- 暂时性修复 contenteditable 的 bug #9 -->

--- a/src/components/task/TaskList.vue
+++ b/src/components/task/TaskList.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { Icon } from '@iconify/vue'
-import { SpecialProjectNames, useTaskStore } from '@/store'
-import { isDark } from '@/composable/dark'
 import draggable from 'vuedraggable'
 import TaskItem from './TaskItem.vue'
+import { SpecialProjectNames, useTaskStore } from '@/store'
+import { isDark } from '@/composable/dark'
 import { useInput } from '@/hooks'
 
 const taskStore = useTaskStore()
@@ -27,10 +27,10 @@ function addTask() {
 const shouldShowTodoAdd = computed(() => {
   const name = taskStore.currentActiveProject?.name
   return (
-    name !== (SpecialProjectNames.Complete as string) &&
-    name !== SpecialProjectNames.Trash &&
-    name !== SpecialProjectNames.Failed &&
-    name !== SpecialProjectNames.Abstract
+    name !== (SpecialProjectNames.Complete as string)
+    && name !== SpecialProjectNames.Trash
+    && name !== SpecialProjectNames.Failed
+    && name !== SpecialProjectNames.Abstract
   )
 })
 
@@ -55,7 +55,7 @@ const { inputRef, onFocus } = useInput()
         type="text"
         class="w-100% min-w-300px h-38px rounded-6px p-4px pl-12px pr-12px outline-none border-1 b-transparent bg-gray-100 dark:bg-#3B3B3B"
         @keypress.enter="addTask"
-      />
+      >
       <div
         v-show="isPlaceholder"
         class="w-100% min-w-300px absolute top-0 flex items-center h-38px p-4px pl-12px pr-12px border-1 b-transparent select-none color-gray:50"

--- a/src/components/task/TaskList.vue
+++ b/src/components/task/TaskList.vue
@@ -10,7 +10,7 @@ import { useInput } from '@/hooks'
 const taskStore = useTaskStore()
 
 const taskTitle = ref('')
-const dragging = ref(false)
+const dragging = ref<boolean>(false)
 
 const placeholderText = computed(() => {
   return `添加任务至“${taskStore.currentActiveProject?.name}”，回车即可保存`

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,3 @@
+import useInput from './useInput'
+
+export { useInput }

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,0 +1,41 @@
+import { useEventListener } from "@vueuse/core"
+import { Ref, ref } from "vue"
+
+export default function useInput() {
+  const inputRef: Ref<HTMLInputElement | null> = ref(null)
+  useEventListener(
+    () => inputRef.value,
+    'blur',
+    () => {
+      const classList = inputRef.value!.classList
+
+      classList.add('bg-gray-100')
+      classList.add('dark:bg-#3B3B3B')
+
+      classList.remove('border-blue')
+      classList.remove('dark:color-black')
+    },
+  )
+
+  useEventListener(
+    () => inputRef.value,
+    'focus',
+    () => {
+      const classList = inputRef.value!.classList
+
+      classList.add('border-blue')
+      classList.add('dark:color-black')
+      classList.remove('bg-gray-100')
+      classList.remove('dark:bg-#3B3B3B')
+    },
+  )
+
+  function onFocus() {
+    inputRef.value!.focus()
+  }
+
+  return {
+    inputRef,
+    onFocus,
+  }
+}

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,5 +1,6 @@
-import { useEventListener } from "@vueuse/core"
-import { Ref, ref } from "vue"
+import { useEventListener } from '@vueuse/core'
+import type { Ref } from 'vue'
+import { ref } from 'vue'
 
 export default function useInput() {
   const inputRef: Ref<HTMLInputElement | null> = ref(null)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,5 @@
 export { useTaskStore } from './useTaskStore'
+export { useTaskStatusStore } from './useTaskStatus'
 
 export { SpecialProjectNames, TaskState } from '../services/task'
 export type { Task, Project } from '../services/task'

--- a/src/store/useTaskStatus.ts
+++ b/src/store/useTaskStatus.ts
@@ -17,5 +17,5 @@ export const useTaskStatusStore = defineStore(
       listDefaultSelectedKey,
       changeSelectedKey,
     }
-  }
+  },
 )

--- a/src/store/useTaskStatus.ts
+++ b/src/store/useTaskStatus.ts
@@ -8,7 +8,6 @@ export const useTaskStatusStore = defineStore(
     const listDefaultSelectedKey = ref([100])
 
     function changeSelectedKey(key: number[]) {
-      console.log('changeSelectedKey', key)
       selectedKey.value = key
     }
 

--- a/src/store/useTaskStatus.ts
+++ b/src/store/useTaskStatus.ts
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useTaskStatusStore = defineStore(
+  'taskStatus',
+  () => {
+    const selectedKey = ref([101])
+    const listDefaultSelectedKey = ref([100])
+
+    function changeSelectedKey(key: number[]) {
+      console.log('changeSelectedKey', key)
+      selectedKey.value = key
+    }
+
+    return {
+      selectedKey,
+      listDefaultSelectedKey,
+      changeSelectedKey,
+    }
+  }
+)

--- a/src/views/task/TaskLeftListNTree.vue
+++ b/src/views/task/TaskLeftListNTree.vue
@@ -1,0 +1,58 @@
+<template>
+  <NTree
+    v-model:selected-keys="taskStatusStore.selectedKey"
+    :default-expanded-keys="taskStatusStore.listDefaultSelectedKey"
+    block-line
+    :data="data"
+    :node-props="nodeProps"
+    @update:selected-keys="changeSelectedKey"
+  />
+</template>
+
+<script setup lang="ts">
+import { useTaskStatusStore, useTaskStore } from '@/store'
+import { NTree } from 'naive-ui'
+import { ref } from 'vue'
+
+const taskStatusStore = useTaskStatusStore()
+const taskStore = useTaskStore()
+
+const data = ref<any[]>([
+  {
+    key: 100,
+    label: '清单',
+    checkboxDisabled: false,
+    isLeaf: false,
+    children: taskStore.projectNames.map(
+      (projectName, index) => {
+        return {
+          key: 100 + index + 1,
+          label: projectName,
+          isLeaf: true,
+        }
+      }
+    ),
+  },
+])
+const nodeProps = (treeOption: any) => {
+  return {
+    onClick() {
+      const projectName = treeOption.option.label
+      taskStore.changeCurrentActiveProject(projectName)
+    },
+  }
+}
+
+const changeSelectedKey = (key: number[]) => {
+  taskStatusStore.changeSelectedKey(key)
+}
+</script>
+
+<style>
+.n-tree.n-tree--block-line .n-tree-node:not(.n-tree-node--disabled).n-tree-node--pending {
+  background-color: transparent;
+}
+.n-tree.n-tree--block-line .n-tree-node:not(.n-tree-node--disabled).n-tree-node--selected {
+  background-color: var(--n-node-color-active)
+}
+</style>

--- a/src/views/task/TaskLeftListNTree.vue
+++ b/src/views/task/TaskLeftListNTree.vue
@@ -1,18 +1,7 @@
-<template>
-  <NTree
-    v-model:selected-keys="taskStatusStore.selectedKey"
-    :default-expanded-keys="taskStatusStore.listDefaultSelectedKey"
-    block-line
-    :data="data"
-    :node-props="nodeProps"
-    @update:selected-keys="changeSelectedKey"
-  />
-</template>
-
 <script setup lang="ts">
-import { useTaskStatusStore, useTaskStore } from '@/store'
 import { NTree } from 'naive-ui'
 import { ref } from 'vue'
+import { useTaskStatusStore, useTaskStore } from '@/store'
 
 const taskStatusStore = useTaskStatusStore()
 const taskStore = useTaskStore()
@@ -30,7 +19,7 @@ const data = ref<any[]>([
           label: projectName,
           isLeaf: true,
         }
-      }
+      },
     ),
   },
 ])
@@ -47,6 +36,17 @@ const changeSelectedKey = (key: number[]) => {
   taskStatusStore.changeSelectedKey(key)
 }
 </script>
+
+<template>
+  <NTree
+    v-model:selected-keys="taskStatusStore.selectedKey"
+    :default-expanded-keys="taskStatusStore.listDefaultSelectedKey"
+    block-line
+    :data="data"
+    :node-props="nodeProps"
+    @update:selected-keys="changeSelectedKey"
+  />
+</template>
 
 <style>
 .n-tree.n-tree--block-line .n-tree-node:not(.n-tree-node--disabled).n-tree-node--pending {

--- a/src/views/task/TaskLeftListProject.vue
+++ b/src/views/task/TaskLeftListProject.vue
@@ -1,53 +1,11 @@
-<template>
-  <ul>
-    <li
-      v-for="item in taskList"
-      :key="item.key"
-      li_common
-      pl-4
-      pr-2
-      hover="bg-[#F3F3F5] dark:bg-[#2D2D30]"
-      :class="
-        taskStatusStore.selectedKey[0] === item.key
-          ? selected
-          : ''
-      "
-      @click="
-        changeSelectedKeyAndActiveProject(
-          item.title,
-          item.key
-        )
-      "
-    >
-      <div flex>
-        <Icon
-          :icon="item.icon"
-          width="20"
-          class="color-[#9D9FA3]"
-          dark="color-white-b"
-        />
-        <span class="ml-2">{{ item.title }}</span>
-      </div>
-
-      <Icon
-        v-show="taskStatusStore.selectedKey[0] === item.key"
-        icon="material-symbols:more-horiz"
-        width="20"
-        class="color-[#9D9FA3]"
-        dark="color-white"
-      />
-    </li>
-  </ul>
-</template>
-
 <script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { reactive } from 'vue'
 import {
   SpecialProjectNames,
   useTaskStatusStore,
   useTaskStore,
 } from '@/store'
-import { Icon } from '@iconify/vue'
-import { reactive } from 'vue'
 
 interface TaskListType {
   key: number
@@ -84,12 +42,54 @@ const taskStatusStore = useTaskStatusStore()
 
 const changeSelectedKeyAndActiveProject = (
   projectName: string,
-  key: number
+  key: number,
 ) => {
   taskStore.changeCurrentActiveProject(projectName)
   console.log(key)
   taskStatusStore.changeSelectedKey([key])
 }
 </script>
+
+<template>
+  <ul>
+    <li
+      v-for="item in taskList"
+      :key="item.key"
+      li_common
+      pl-4
+      pr-2
+      hover="bg-[#F3F3F5] dark:bg-[#2D2D30]"
+      :class="
+        taskStatusStore.selectedKey[0] === item.key
+          ? selected
+          : ''
+      "
+      @click="
+        changeSelectedKeyAndActiveProject(
+          item.title,
+          item.key,
+        )
+      "
+    >
+      <div flex>
+        <Icon
+          :icon="item.icon"
+          width="20"
+          class="color-[#9D9FA3]"
+          dark="color-white-b"
+        />
+        <span class="ml-2">{{ item.title }}</span>
+      </div>
+
+      <Icon
+        v-show="taskStatusStore.selectedKey[0] === item.key"
+        icon="material-symbols:more-horiz"
+        width="20"
+        class="color-[#9D9FA3]"
+        dark="color-white"
+      />
+    </li>
+  </ul>
+</template>
 
 <style scoped></style>

--- a/src/views/task/TaskLeftListProject.vue
+++ b/src/views/task/TaskLeftListProject.vue
@@ -45,7 +45,6 @@ const changeSelectedKeyAndActiveProject = (
   key: number,
 ) => {
   taskStore.changeCurrentActiveProject(projectName)
-  console.log(key)
   taskStatusStore.changeSelectedKey([key])
 }
 </script>

--- a/src/views/task/TaskLeftListProject.vue
+++ b/src/views/task/TaskLeftListProject.vue
@@ -1,0 +1,95 @@
+<template>
+  <ul>
+    <li
+      v-for="item in taskList"
+      :key="item.key"
+      li_common
+      pl-4
+      pr-2
+      hover="bg-[#F3F3F5] dark:bg-[#2D2D30]"
+      :class="
+        taskStatusStore.selectedKey[0] === item.key
+          ? selected
+          : ''
+      "
+      @click="
+        changeSelectedKeyAndActiveProject(
+          item.title,
+          item.key
+        )
+      "
+    >
+      <div flex>
+        <Icon
+          :icon="item.icon"
+          width="20"
+          class="color-[#9D9FA3]"
+          dark="color-white-b"
+        />
+        <span class="ml-2">{{ item.title }}</span>
+      </div>
+
+      <Icon
+        v-show="taskStatusStore.selectedKey[0] === item.key"
+        icon="material-symbols:more-horiz"
+        width="20"
+        class="color-[#9D9FA3]"
+        dark="color-white"
+      />
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import {
+  SpecialProjectNames,
+  useTaskStatusStore,
+  useTaskStore,
+} from '@/store'
+import { Icon } from '@iconify/vue'
+import { reactive } from 'vue'
+
+interface TaskListType {
+  key: number
+  icon: string
+  title: `${SpecialProjectNames}`
+}
+
+const taskList = reactive<TaskListType[]>([
+  {
+    key: 1,
+    icon: 'material-symbols:check-box',
+    title: SpecialProjectNames.Complete,
+  },
+  {
+    key: 2,
+    icon: 'mdi:close-box',
+    title: SpecialProjectNames.Failed,
+  },
+  {
+    key: 3,
+    icon: 'material-symbols:delete',
+    title: SpecialProjectNames.Trash,
+  },
+  {
+    key: 4,
+    icon: 'material-symbols:text-snippet-rounded',
+    title: SpecialProjectNames.Abstract,
+  },
+])
+const selected = 'bg-[#E7F5EE] dark:bg-[#233633]'
+
+const taskStore = useTaskStore()
+const taskStatusStore = useTaskStatusStore()
+
+const changeSelectedKeyAndActiveProject = (
+  projectName: string,
+  key: number
+) => {
+  taskStore.changeCurrentActiveProject(projectName)
+  console.log(key)
+  taskStatusStore.changeSelectedKey([key])
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
+ 把 `taskLefListView` 拆分成了两个子组件，并重构了对应的实现。

+ 把 `taskLefListView` 中存在的 `active`  样式的 bug 修了

**bug:**
> 当你刚进入页面的时候点击下方 Project 时，上面 Tree 会留有一个 n-tree-pending 的样式
> 但是当你进入页面点击任何一个上方的 Tree 时，再点击下方的 Project，就又正常了
